### PR TITLE
feat: fetch posts from WordPress

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This project demonstrates fetching data from the WordPress REST API using Vue 3.
 
 Open `index.html` in a browser to see the latest posts from [WordPress.org News](https://wordpress.org/news/).
+
+The page includes basic SEO enhancements such as meta tags, canonical links, Open Graph data and semantic markup for each post so search engines can index the content.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # vuejs3
+
+This project demonstrates fetching data from the WordPress REST API using Vue 3.
+
+Open `index.html` in a browser to see the latest posts from [WordPress.org News](https://wordpress.org/news/).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Vue 3 WordPress Integration</title>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+</head>
+<body>
+  <div id="app">
+    <h1>WordPress Posts</h1>
+    <p v-if="error">{{ error }}</p>
+    <ul v-else>
+      <li v-for="post in posts" :key="post.id" v-html="post.title.rendered"></li>
+    </ul>
+  </div>
+  <script type="module">
+    const { createApp, ref, onMounted } = Vue;
+
+    createApp({
+      setup() {
+        const posts = ref([]);
+        const error = ref('');
+
+        async function fetchPosts() {
+          try {
+            const res = await fetch('https://wordpress.org/news/wp-json/wp/v2/posts');
+            if (!res.ok) throw new Error('Failed to fetch posts');
+            posts.value = await res.json();
+          } catch (err) {
+            error.value = err.message;
+          }
+        }
+
+        onMounted(fetchPosts);
+
+        return { posts, error };
+      }
+    }).mount('#app');
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -2,17 +2,38 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Sample Vue 3 app fetching posts from the WordPress REST API." />
+  <meta name="keywords" content="Vue 3, WordPress, SEO" />
+  <meta name="robots" content="index, follow" />
+  <link rel="preconnect" href="https://wordpress.org" />
+  <link rel="canonical" href="https://example.com/" />
+  <meta property="og:title" content="Vue 3 WordPress Integration" />
+  <meta property="og:description" content="Sample app that fetches posts from WordPress using Vue 3" />
+  <meta property="og:type" content="website" />
   <title>Vue 3 WordPress Integration</title>
   <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    "url": "https://example.com/",
+    "headline": "Vue 3 WordPress Integration",
+    "description": "Sample app that fetches posts from WordPress using Vue 3"
+  }
+  </script>
 </head>
 <body>
-  <div id="app">
+  <main id="app">
     <h1>WordPress Posts</h1>
     <p v-if="error">{{ error }}</p>
-    <ul v-else>
-      <li v-for="post in posts" :key="post.id" v-html="post.title.rendered"></li>
-    </ul>
-  </div>
+    <section v-else>
+      <article v-for="post in posts" :key="post.id">
+        <h2><a :href="post.link" v-html="post.title.rendered"></a></h2>
+      </article>
+    </section>
+  </main>
+  <noscript>This page requires JavaScript to display WordPress posts.</noscript>
   <script type="module">
     const { createApp, ref, onMounted } = Vue;
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "vuejs3",
+  "version": "1.0.0",
+  "description": "Demo Vue 3 app fetching WordPress posts",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests available\""
+  },
+  "keywords": [
+    "vue3",
+    "wordpress"
+  ],
+  "author": "",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- add Vue 3 example page that fetches posts from WordPress REST API
- document how to view the WordPress-backed example
- add package.json with placeholder test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c119e78b8832abf726a766e51dd71